### PR TITLE
Fix template auth defaults + aggregate/thin dual topology

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,52 @@
+# Game template environment (copy to .env and adjust)
+
+# --- App ---
+APP_NAME=game0
+APP_ID=game0
+DEPLOYMENT=local
+VERSION=0.0.1
+
+# --- Auth (platform AuthMiddlewareModule / AuthAllModule) ---
+AUTH_URL=localhost:8081
+AUTH_STORE_NAME=auth
+JWT_TOKEN_SECRET=change-me-in-prod
+JWT_TOKEN_EXPIRE=12
+
+# --- TLS / mTLS ---
+TLS_ENABLE=false
+MTLS_ENABLE=false
+TCP_TLS_ENABLE=false
+SERVER_NAME=
+# CLIENT_CA_CERT=./configs/tls-client/ca.crt
+# CLIENT_CERT=./configs/tls-client/tls.crt
+# CLIENT_KEY=./configs/tls-client/tls.key
+# SERVER_CA_CERT=./configs/tls-server/ca.crt
+# SERVER_CERT=./configs/tls-server/tls.crt
+# SERVER_KEY=./configs/tls-server/tls.key
+
+# --- CORS (required non-empty in prod when gateway is enabled; kit #224+) ---
+CORS_ALLOW_ORIGINS=*
+
+# --- NATS ---
+NATS_URL=nats://localhost:4222
+
+# --- Mongo ---
+DATABASE_URL=mongodb://localhost:27017
+DATABASE_USER=
+DATABASE_PASSWORD=
+DB_NAME=game
+
+# --- Redis ---
+CACHE_URL=redis://localhost:6379
+CACHE_USER=
+CACHE_PASSWORD=
+
+# --- Server ports ---
+PORT=8081
+ZINX_TCP_PORT=8888
+GAME_URL=localhost:8081
+
+# Thin topology: point these at remote platform services when using
+# cmd/game0/service-thin (in addition to AUTH_URL above).
+# PROFILE_URL=localhost:8081
+# MAIL_URL=localhost:8081

--- a/.env.example
+++ b/.env.example
@@ -46,8 +46,9 @@ CACHE_PASSWORD=
 
 # --- Server ports (this game process) ---
 PORT=8081
-ZINX_TCP_PORT=8888
 GAME_URL=localhost:8081
+# TCP/zinx is opt-in (TcpModule / AllWithTcpModule) and has NO gRPC auth.
+# ZINX_TCP_PORT=8888
 
 # Thin topology: remote platform clients (must not equal this game's PORT unless
 # those services are co-hosted — they are not in service-thin).

--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,10 @@ DEPLOYMENT=local
 VERSION=0.0.1
 
 # --- Auth (platform AuthMiddlewareModule / AuthAllModule) ---
-AUTH_URL=localhost:8081
+# Aggregate (cmd/game0/service): AuthService is in-process; AUTH_URL can match PORT.
+# Thin (cmd/game0/service-thin): MUST point at a remote AuthService — NOT this game's PORT.
+#   Example when platform auth listens on 8082 while game uses 8081:
+AUTH_URL=localhost:8082
 AUTH_STORE_NAME=auth
 JWT_TOKEN_SECRET=change-me-in-prod
 JWT_TOKEN_EXPIRE=12
@@ -41,12 +44,13 @@ CACHE_URL=redis://localhost:6379
 CACHE_USER=
 CACHE_PASSWORD=
 
-# --- Server ports ---
+# --- Server ports (this game process) ---
 PORT=8081
 ZINX_TCP_PORT=8888
 GAME_URL=localhost:8081
 
-# Thin topology: point these at remote platform services when using
-# cmd/game0/service-thin (in addition to AUTH_URL above).
-# PROFILE_URL=localhost:8081
-# MAIL_URL=localhost:8081
+# Thin topology: remote platform clients (must not equal this game's PORT unless
+# those services are co-hosted — they are not in service-thin).
+# PROFILE_URL=localhost:8082
+# MAIL_URL=localhost:8082
+# KNAPSACK_URL=localhost:8082

--- a/.env.example
+++ b/.env.example
@@ -7,13 +7,13 @@ DEPLOYMENT=local
 VERSION=0.0.1
 
 # --- Auth (platform AuthMiddlewareModule / AuthAllModule) ---
-# Aggregate (cmd/game0/service): AuthService is in-process; AUTH_URL can match PORT.
-# Thin (cmd/game0/service-thin): MUST point at a remote AuthService — NOT this game's PORT.
-#   Example when platform auth listens on 8082 while game uses 8081:
-AUTH_URL=localhost:8082
+# Aggregate default: AuthService is in-process on PORT — AUTH_URL should match.
+AUTH_URL=localhost:8081
 AUTH_STORE_NAME=auth
 JWT_TOKEN_SECRET=change-me-in-prod
 JWT_TOKEN_EXPIRE=12
+# Thin (cmd/game0/service-thin): override AUTH_URL to the remote AuthService,
+# e.g. AUTH_URL=localhost:8082 — never point it at this game's PORT.
 
 # --- TLS / mTLS ---
 TLS_ENABLE=false

--- a/.env.example
+++ b/.env.example
@@ -47,7 +47,7 @@ CACHE_PASSWORD=
 # --- Server ports (this game process) ---
 PORT=8081
 GAME_URL=localhost:8081
-# TCP/zinx is opt-in (TcpModule / AllWithTcpModule) and has NO gRPC auth.
+# TCP/zinx is opt-in (TcpModule / AllWithTCPModule) and has NO gRPC auth.
 # ZINX_TCP_PORT=8888
 
 # Thin topology: remote platform clients (must not equal this game's PORT unless

--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ which is designed to provide a basic game server framework for developers.
 | Entry | Path | Use when |
 |-------|------|----------|
 | **Aggregate** | `cmd/game0/service` | Local/dev: game + in-process platform modules (`AuthAllModule`) |
-| **Thin** | `cmd/game0/service-thin` | Prod-like split: game-only + remote platform clients (`AuthMiddlewareModule`, set `AUTH_URL`) |
+| **Thin** | `cmd/game0/service-thin` | Prod-like split: game-only + remote platform clients (`AuthMiddlewareModule`) |
 
 Public game APIs require auth by default (`AuthMiddlewareModule` / `AuthAllModule`). Do not embed `utility.WithoutAuth` on public services.
 
 Copy `.env.example` → `.env` for AUTH/TLS/CORS/NATS/Mongo/Redis knobs.
+
+**Thin `AUTH_URL`:** must point at a **remote** AuthService (default example `localhost:8082`). Do not set it to this game's `PORT` (`8081`) — thin does not host auth, so middleware would dial itself and fail.
 
 ## How to run
 
@@ -34,8 +36,9 @@ Copy `.env.example` → `.env` for AUTH/TLS/CORS/NATS/Mongo/Redis knobs.
     go run ./cmd/{game-name}/service/main.go
   ```
 
-* or thin (remote platform):
+* or thin (remote platform auth/clients must already be reachable):
   ```shell
+    # AUTH_URL=localhost:8082 (not the game PORT)
     go run ./cmd/game0/service-thin/main.go
   ```
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,17 @@ which is designed to provide a basic game server framework for developers.
 
 ![architecture](./draws/game.drawio.png)
 
+### Topologies
+
+| Entry | Path | Use when |
+|-------|------|----------|
+| **Aggregate** | `cmd/game0/service` | Local/dev: game + in-process platform modules (`AuthAllModule`) |
+| **Thin** | `cmd/game0/service-thin` | Prod-like split: game-only + remote platform clients (`AuthMiddlewareModule`, set `AUTH_URL`) |
+
+Public game APIs require auth by default (`AuthMiddlewareModule` / `AuthAllModule`). Do not embed `utility.WithoutAuth` on public services.
+
+Copy `.env.example` → `.env` for AUTH/TLS/CORS/NATS/Mongo/Redis knobs.
+
 ## How to run
 
 * deploy infrastructure:
@@ -17,10 +28,15 @@ which is designed to provide a basic game server framework for developers.
    docker compose -f ./deployment/docker-compose/infrastructure.yaml up -d
   ```
 
-* run service:
+* run service (aggregate):
   ```shell
   # fix the game-name to your game name 
     go run ./cmd/{game-name}/service/main.go
+  ```
+
+* or thin (remote platform):
+  ```shell
+    go run ./cmd/game0/service-thin/main.go
   ```
 
 ## How to build docker image?

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ which is designed to provide a basic game server framework for developers.
 
 Public game APIs require auth by default (`AuthMiddlewareModule` / `AuthAllModule`). Do not embed `utility.WithoutAuth` on public services.
 
-Default `AllModule` exposes **gRPC + HTTP only**. TCP/zinx is **not** covered by AuthMiddleware (uid can be spoofed); enable only via `TcpModule` / `AllWithTcpModule` on trusted networks.
+Default `AllModule` exposes **gRPC + HTTP only**. TCP/zinx is **not** covered by AuthMiddleware (uid can be spoofed); enable only via `TcpModule` / `AllWithTCPModule` on trusted networks.
 
 Copy `.env.example` → `.env` for AUTH/TLS/CORS/NATS/Mongo/Redis knobs.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ which is designed to provide a basic game server framework for developers.
 
 Public game APIs require auth by default (`AuthMiddlewareModule` / `AuthAllModule`). Do not embed `utility.WithoutAuth` on public services.
 
+Default `AllModule` exposes **gRPC + HTTP only**. TCP/zinx is **not** covered by AuthMiddleware (uid can be spoofed); enable only via `TcpModule` / `AllWithTcpModule` on trusted networks.
+
 Copy `.env.example` → `.env` for AUTH/TLS/CORS/NATS/Mongo/Redis knobs.
 
 **`AUTH_URL`:**
@@ -77,8 +79,10 @@ docker buildx build -t <your_register_url>:latest --build-arg APP_NAME=<your_ser
 * install [k6](https://grafana.com/docs/k6/latest/get-started/installation/)
 * run k6 load test
    ``` shell
-    # fix the game-name to your game name
-    k6 run ./tests/{game-name}/{game-name}.js
+    # aggregate (auth on same host as game)
+    k6 run ./tests/game0/game0.js
+    # thin: Authenticate against remote auth
+    AUTH_HOST=127.0.0.1:8082 SERVER_HOST=127.0.0.1:8081 k6 run ./tests/game0/game0.js
   ```
 
 ## Proto file Manage

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ Public game APIs require auth by default (`AuthMiddlewareModule` / `AuthAllModul
 
 Copy `.env.example` → `.env` for AUTH/TLS/CORS/NATS/Mongo/Redis knobs.
 
-**Thin `AUTH_URL`:** must point at a **remote** AuthService (default example `localhost:8082`). Do not set it to this game's `PORT` (`8081`) — thin does not host auth, so middleware would dial itself and fail.
+**`AUTH_URL`:**
+- Aggregate: keep aligned with `PORT` (`.env.example` default `localhost:8081`).
+- Thin: override to a **remote** AuthService (e.g. `localhost:8082`). Do not use this game's `PORT` — thin does not host auth.
 
 ## How to run
 
@@ -38,7 +40,7 @@ Copy `.env.example` → `.env` for AUTH/TLS/CORS/NATS/Mongo/Redis knobs.
 
 * or thin (remote platform auth/clients must already be reachable):
   ```shell
-    # AUTH_URL=localhost:8082 (not the game PORT)
+    # override AUTH_URL away from PORT, e.g. AUTH_URL=localhost:8082
     go run ./cmd/game0/service-thin/main.go
   ```
 
@@ -62,8 +64,11 @@ docker buildx build -t <your_register_url>:latest --build-arg APP_NAME=<your_ser
    ```
 * run your interactive client:
     ```shell
-     # help
-     ./{game-name}.exe shell
+     # aggregate (auth on same host)
+     ./{game-name} grpc --host localhost:8081
+     # thin (auth on remote AUTH_URL)
+     ./{game-name} grpc --host localhost:8081 --auth-host localhost:8082
+     # flow: auth token → game token <access> → game hi
     ```
   tips: http client use Postman to connect `localhost:8081`.
 

--- a/cmd/game0/client/main.go
+++ b/cmd/game0/client/main.go
@@ -9,8 +9,9 @@ import (
 )
 
 var options struct {
-	host    string
-	tcpHost string
+	host     string
+	authHost string
+	tcpHost  string
 }
 
 const (
@@ -28,9 +29,14 @@ func main() {
 		&options.host,
 		"host",
 		defaultHost,
-		"grpc http service (<host>:<port>)",
+		"game grpc/http service (<host>:<port>)",
 	)
-
+	rootCmd.PersistentFlags().StringVar(
+		&options.authHost,
+		"auth-host",
+		"",
+		"auth grpc service (<host>:<port>); default: AUTH_URL env or --host (aggregate)",
+	)
 	rootCmd.PersistentFlags().StringVar(
 		&options.tcpHost,
 		"tcp_host",
@@ -42,7 +48,10 @@ func main() {
 		Use:   "grpc",
 		Short: "Run an interactive grpc client",
 		Run: func(cmd *cobra.Command, args []string) {
-			game0.RunGrpc(options.host)
+			game0.RunGrpcWithOptions(game0.RunGrpcOptions{
+				GameURL: options.host,
+				AuthURL: options.authHost,
+			})
 		},
 	}
 	sTcp := &cobra.Command{

--- a/cmd/game0/service-thin/main.go
+++ b/cmd/game0/service-thin/main.go
@@ -18,8 +18,10 @@ import (
 )
 
 // Thin topology: game-only process talking to remote platform over gRPC clients.
-// Set AUTH_URL (and other *_URL envs) to the remote platform endpoints.
-// AuthMiddlewareModule validates tokens via the remote AuthService.
+//
+// AUTH_URL must target a remote AuthService (see .env.example → localhost:8082).
+// Do not point AUTH_URL at this process's PORT — thin does not host AuthService.
+// AuthMiddlewareModule validates tokens via that remote AuthService.
 func main() {
 	fxmain.Main(
 		mfx.NatsModule,

--- a/cmd/game0/service-thin/main.go
+++ b/cmd/game0/service-thin/main.go
@@ -5,42 +5,38 @@ import (
 	"github.com/gstones/moke-kit/mq/pkg/mfx"
 	"github.com/gstones/moke-kit/orm/pkg/ofx"
 
-	analytics "github.com/moke-game/platform/services/analytics/pkg/module"
 	auth "github.com/moke-game/platform/services/auth/pkg/module"
 	buddy "github.com/moke-game/platform/services/buddy/pkg/module"
 	chat "github.com/moke-game/platform/services/chat/pkg/module"
 	knapsack "github.com/moke-game/platform/services/knapsack/pkg/module"
 	leaderboard "github.com/moke-game/platform/services/leaderboard/pkg/module"
 	mail "github.com/moke-game/platform/services/mail/pkg/module"
-	matchmaking "github.com/moke-game/platform/services/matchmaking/pkg/module"
 	party "github.com/moke-game/platform/services/party/pkg/module"
 	profile "github.com/moke-game/platform/services/profile/pkg/module"
 
 	"github.com/moke-game/game/pkg/modules"
 )
 
-// Aggregate topology: game + in-process platform modules (local/dev demo).
-// AuthAllModule hosts AuthService and enables AuthMiddleware for public RPCs.
+// Thin topology: game-only process talking to remote platform over gRPC clients.
+// Set AUTH_URL (and other *_URL envs) to the remote platform endpoints.
+// AuthMiddlewareModule validates tokens via the remote AuthService.
 func main() {
 	fxmain.Main(
-		// infrastructures
 		mfx.NatsModule,
 		mfx.LocalModule,
 		ofx.RedisCacheModule,
 
-		// game transports (auth comes from AuthAllModule below)
+		// game public API
 		modules.AllModule,
 
-		// in-process platform services
-		mail.MailModule,
-		analytics.AnalyticsModule,
-		auth.AuthAllModule,
-		profile.ProfileModule,
-		knapsack.KnapsackModule,
-		party.PartyModule,
-		buddy.BuddyModule,
-		leaderboard.LeaderboardModule,
-		chat.ChatModule,
-		matchmaking.MatchmakingModule,
+		// remote auth middleware + platform clients
+		auth.AuthMiddlewareModule,
+		profile.ProfileClientModule,
+		mail.MailClientModule,
+		knapsack.KnapsackClientModule,
+		party.PartyClientModule,
+		buddy.BuddyClientModule,
+		leaderboard.LeaderboardClientPublic,
+		chat.ChatClientModule,
 	)
 }

--- a/cmd/game0/service-thin/main.go
+++ b/cmd/game0/service-thin/main.go
@@ -19,9 +19,10 @@ import (
 
 // Thin topology: game-only process talking to remote platform over gRPC clients.
 //
-// AUTH_URL must target a remote AuthService (see .env.example → localhost:8082).
+// Override AUTH_URL to a remote AuthService (e.g. localhost:8082).
 // Do not point AUTH_URL at this process's PORT — thin does not host AuthService.
 // AuthMiddlewareModule validates tokens via that remote AuthService.
+// Interactive client: --auth-host (or AUTH_URL) must match that remote auth.
 func main() {
 	fxmain.Main(
 		mfx.NatsModule,

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3
 	github.com/gstones/moke-kit v1.0.5-0.20260811085843-60e104db6db7
 	github.com/gstones/zinx v1.2.7-0.20240617071724-88bd884d8d08
-	github.com/moke-game/platform v0.0.0-20260811115401-66c14d25cc5f
+	github.com/moke-game/platform v0.0.0-20260811123400-b0cd3d45e29e
 	github.com/redis/go-redis/v9 v9.7.3
 	github.com/spf13/cobra v1.9.1
 	go.uber.org/fx v1.23.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3
 	github.com/gstones/moke-kit v1.0.5-0.20260811085843-60e104db6db7
 	github.com/gstones/zinx v1.2.7-0.20240617071724-88bd884d8d08
-	github.com/moke-game/platform v0.0.0-20260811094427-431297109062
+	github.com/moke-game/platform v0.0.0-20260811113754-eb1cea52779c
 	github.com/redis/go-redis/v9 v9.7.3
 	github.com/spf13/cobra v1.9.1
 	go.uber.org/fx v1.23.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3
 	github.com/gstones/moke-kit v1.0.5-0.20260811085843-60e104db6db7
 	github.com/gstones/zinx v1.2.7-0.20240617071724-88bd884d8d08
-	github.com/moke-game/platform v0.0.0-20260811113754-eb1cea52779c
+	github.com/moke-game/platform v0.0.0-20260811115401-66c14d25cc5f
 	github.com/redis/go-redis/v9 v9.7.3
 	github.com/spf13/cobra v1.9.1
 	go.uber.org/fx v1.23.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3
 	github.com/gstones/moke-kit v1.0.5-0.20260811085843-60e104db6db7
 	github.com/gstones/zinx v1.2.7-0.20240617071724-88bd884d8d08
-	github.com/moke-game/platform v0.0.0-20260811123400-b0cd3d45e29e
+	github.com/moke-game/platform v0.0.0-20260811124049-a79572077ebb
 	github.com/redis/go-redis/v9 v9.7.3
 	github.com/spf13/cobra v1.9.1
 	go.uber.org/fx v1.23.0

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/abiosoft/ishell v2.0.0+incompatible
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.1
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3
-	github.com/gstones/moke-kit v1.0.5-0.20250414125136-0f0537f47883
+	github.com/gstones/moke-kit v1.0.5-0.20260811085843-60e104db6db7
 	github.com/gstones/zinx v1.2.7-0.20240617071724-88bd884d8d08
-	github.com/moke-game/platform v0.0.0-20250415025501-5e99e8ee1e09
+	github.com/moke-game/platform v0.0.0-20260811094427-431297109062
 	github.com/redis/go-redis/v9 v9.7.3
 	github.com/spf13/cobra v1.9.1
 	go.uber.org/fx v1.23.0

--- a/go.sum
+++ b/go.sum
@@ -205,8 +205,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/moke-game/platform v0.0.0-20260811113754-eb1cea52779c h1:62OCqFM79Cunk1hZUOkSZCHvgDaqsZb9fkY89uq0sEI=
-github.com/moke-game/platform v0.0.0-20260811113754-eb1cea52779c/go.mod h1:Ws/Kx2teblj8rmXcQJwAQn5NJTk7Aoz1yW0Z63EWHwI=
+github.com/moke-game/platform v0.0.0-20260811115401-66c14d25cc5f h1:VjMRdZ7bEgYyeEfbfwaRugjUY4HF80wZmlDCO5C87Y4=
+github.com/moke-game/platform v0.0.0-20260811115401-66c14d25cc5f/go.mod h1:Ws/Kx2teblj8rmXcQJwAQn5NJTk7Aoz1yW0Z63EWHwI=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=
 github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=

--- a/go.sum
+++ b/go.sum
@@ -205,8 +205,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/moke-game/platform v0.0.0-20260811123400-b0cd3d45e29e h1:PC9knG0O4FQEJQUAoxo3ySV7LZhIy0A/DwV7sucS9iU=
-github.com/moke-game/platform v0.0.0-20260811123400-b0cd3d45e29e/go.mod h1:Ws/Kx2teblj8rmXcQJwAQn5NJTk7Aoz1yW0Z63EWHwI=
+github.com/moke-game/platform v0.0.0-20260811124049-a79572077ebb h1:UiScKbssLgmzDCw3vOzGYvu9d2Fs2DiWv073dbaoBxA=
+github.com/moke-game/platform v0.0.0-20260811124049-a79572077ebb/go.mod h1:Ws/Kx2teblj8rmXcQJwAQn5NJTk7Aoz1yW0Z63EWHwI=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=
 github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=

--- a/go.sum
+++ b/go.sum
@@ -205,8 +205,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/moke-game/platform v0.0.0-20260811115401-66c14d25cc5f h1:VjMRdZ7bEgYyeEfbfwaRugjUY4HF80wZmlDCO5C87Y4=
-github.com/moke-game/platform v0.0.0-20260811115401-66c14d25cc5f/go.mod h1:Ws/Kx2teblj8rmXcQJwAQn5NJTk7Aoz1yW0Z63EWHwI=
+github.com/moke-game/platform v0.0.0-20260811123400-b0cd3d45e29e h1:PC9knG0O4FQEJQUAoxo3ySV7LZhIy0A/DwV7sucS9iU=
+github.com/moke-game/platform v0.0.0-20260811123400-b0cd3d45e29e/go.mod h1:Ws/Kx2teblj8rmXcQJwAQn5NJTk7Aoz1yW0Z63EWHwI=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=
 github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=

--- a/go.sum
+++ b/go.sum
@@ -205,8 +205,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/moke-game/platform v0.0.0-20260811094427-431297109062 h1:cFrPPOI3t8glHPuICruVr46mkeKi/JN8ghPi6aufaYU=
-github.com/moke-game/platform v0.0.0-20260811094427-431297109062/go.mod h1:Ws/Kx2teblj8rmXcQJwAQn5NJTk7Aoz1yW0Z63EWHwI=
+github.com/moke-game/platform v0.0.0-20260811113754-eb1cea52779c h1:62OCqFM79Cunk1hZUOkSZCHvgDaqsZb9fkY89uq0sEI=
+github.com/moke-game/platform v0.0.0-20260811113754-eb1cea52779c/go.mod h1:Ws/Kx2teblj8rmXcQJwAQn5NJTk7Aoz1yW0Z63EWHwI=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=
 github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=

--- a/go.sum
+++ b/go.sum
@@ -135,8 +135,8 @@ github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.1 h1:KcFzXwzM/kGhIRHvc8jdix
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.1/go.mod h1:qOchhhIlmRcqk/O9uCo/puJlyo07YINaIqdZfZG3Jkc=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 h1:5ZPtiqj0JL5oKWmcsq4VMaAW5ukBEgSGXEN89zeH1Jo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3/go.mod h1:ndYquD05frm2vACXE1nsccT4oJzjhw2arTS2cpUD1PI=
-github.com/gstones/moke-kit v1.0.5-0.20250414125136-0f0537f47883 h1:spAnuLc/C7AIaMxbdUb2NGfJM87RxzPCjm1dGg56on4=
-github.com/gstones/moke-kit v1.0.5-0.20250414125136-0f0537f47883/go.mod h1:jJsse+hpKKiP3t0i3lutXQjq3tmobqe59mVDUvysjvQ=
+github.com/gstones/moke-kit v1.0.5-0.20260811085843-60e104db6db7 h1:0NIOJm4M6x/sFMB6eTI3ahjFzGhtjQk4c+vPiQJz+6A=
+github.com/gstones/moke-kit v1.0.5-0.20260811085843-60e104db6db7/go.mod h1:jJsse+hpKKiP3t0i3lutXQjq3tmobqe59mVDUvysjvQ=
 github.com/gstones/zinx v1.2.7-0.20240617071724-88bd884d8d08 h1:YjrnGjuIRVs2t0MjMs4DFQox9GH/4jlOELMRVD5d+xg=
 github.com/gstones/zinx v1.2.7-0.20240617071724-88bd884d8d08/go.mod h1:tgm/iZBMyKKZj4totfeu4+PMzSLb4JH8pnGdcG3ql+8=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -205,8 +205,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/moke-game/platform v0.0.0-20250415025501-5e99e8ee1e09 h1:y5amd2mVJw+Kz6AWJ61Dlm62jsOXZhvicpeeH6Slpao=
-github.com/moke-game/platform v0.0.0-20250415025501-5e99e8ee1e09/go.mod h1:KDYqukGz7n/H6k4bNQKW8rqLyKU7OFjVbOSjHr0FJdg=
+github.com/moke-game/platform v0.0.0-20260811094427-431297109062 h1:cFrPPOI3t8glHPuICruVr46mkeKi/JN8ghPi6aufaYU=
+github.com/moke-game/platform v0.0.0-20260811094427-431297109062/go.mod h1:Ws/Kx2teblj8rmXcQJwAQn5NJTk7Aoz1yW0Z63EWHwI=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=
 github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=

--- a/internal/clients/game0/grpc_cli.go
+++ b/internal/clients/game0/grpc_cli.go
@@ -2,6 +2,7 @@ package game0
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -62,13 +63,13 @@ func (p *DemoGrpc) initSubShells() {
 	})
 	p.cmd.AddCmd(&ishell.Cmd{
 		Name:    "hi",
-		Help:    "say hi",
+		Help:    "say hi (requires game token first)",
 		Aliases: []string{"hi"},
 		Func:    p.sayHi,
 	})
 	p.cmd.AddCmd(&ishell.Cmd{
 		Name:    "watch",
-		Help:    "watch topic",
+		Help:    "watch topic (requires game token first)",
 		Aliases: []string{"w"},
 		Func:    p.watch,
 	})
@@ -78,22 +79,31 @@ func (p *DemoGrpc) setToken(c *ishell.Context) {
 	c.ShowPrompt(false)
 	defer c.ShowPrompt(true)
 	tok := slogger.ReadLine(c, "access token: ")
+	if tok == "" {
+		slogger.Warn(c, errors.New("empty token; run: auth token <id>, then paste access token here"))
+		return
+	}
 	p.SetAccessToken(tok)
 	slogger.Infof(c, "token set (%d chars)", len(tok))
 }
 
-func (p *DemoGrpc) authCtx() context.Context {
+func (p *DemoGrpc) authCtx() (context.Context, error) {
 	tok := p.accessToken()
 	if tok == "" {
-		tok = "test"
+		return nil, errors.New("no access token; run: auth token → game token <access>")
 	}
 	md := metadata.Pairs("authorization", fmt.Sprintf("%s %s", "bearer", tok))
-	return mm.MD(md).ToOutgoing(context.Background())
+	return mm.MD(md).ToOutgoing(context.Background()), nil
 }
 
 func (p *DemoGrpc) sayHi(c *ishell.Context) {
 	c.ShowPrompt(false)
 	defer c.ShowPrompt(true)
+	ctx, err := p.authCtx()
+	if err != nil {
+		slogger.Warn(c, err)
+		return
+	}
 	msg := "hello"
 	in := slogger.ReadLine(c, "message(default:hello): ")
 	if in != "" {
@@ -104,7 +114,7 @@ func (p *DemoGrpc) sayHi(c *ishell.Context) {
 	if t != "" {
 		topic = t
 	}
-	if response, err := p.client.Hi(p.authCtx(), &pb.HiRequest{
+	if response, err := p.client.Hi(ctx, &pb.HiRequest{
 		Uid:     "10000",
 		Message: msg,
 		Topic:   topic,
@@ -119,13 +129,19 @@ func (p *DemoGrpc) watch(c *ishell.Context) {
 	c.ShowPrompt(false)
 	defer c.ShowPrompt(true)
 
+	ctx, err := p.authCtx()
+	if err != nil {
+		slogger.Warn(c, err)
+		return
+	}
+
 	topic := "game"
 	t := slogger.ReadLine(c, "topic(default:game): ")
 	if t != "" {
 		topic = t
 	}
 
-	if stream, err := p.client.Watch(p.authCtx(), &pb.WatchRequest{
+	if stream, err := p.client.Watch(ctx, &pb.WatchRequest{
 		Topic: topic,
 	}); err != nil {
 		slogger.Warn(c, err)

--- a/internal/clients/game0/grpc_cli.go
+++ b/internal/clients/game0/grpc_cli.go
@@ -3,6 +3,7 @@ package game0
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	pb "github.com/moke-game/game/api/gen/game0/api"
 
@@ -16,6 +17,9 @@ import (
 type DemoGrpc struct {
 	client pb.Game0ServiceClient
 	cmd    *ishell.Cmd
+
+	mu    sync.RWMutex
+	token string
 }
 
 func NewDemoGrpcCli(conn *grpc.ClientConn) *DemoGrpc {
@@ -36,7 +40,26 @@ func (p *DemoGrpc) GetCmd() *ishell.Cmd {
 	return p.cmd
 }
 
+// SetAccessToken stores the bearer token used by hi/watch.
+func (p *DemoGrpc) SetAccessToken(token string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.token = token
+}
+
+func (p *DemoGrpc) accessToken() string {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.token
+}
+
 func (p *DemoGrpc) initSubShells() {
+	p.cmd.AddCmd(&ishell.Cmd{
+		Name:    "token",
+		Help:    "set access token for subsequent RPCs",
+		Aliases: []string{"t"},
+		Func:    p.setToken,
+	})
 	p.cmd.AddCmd(&ishell.Cmd{
 		Name:    "hi",
 		Help:    "say hi",
@@ -49,7 +72,23 @@ func (p *DemoGrpc) initSubShells() {
 		Aliases: []string{"w"},
 		Func:    p.watch,
 	})
+}
 
+func (p *DemoGrpc) setToken(c *ishell.Context) {
+	c.ShowPrompt(false)
+	defer c.ShowPrompt(true)
+	tok := slogger.ReadLine(c, "access token: ")
+	p.SetAccessToken(tok)
+	slogger.Infof(c, "token set (%d chars)", len(tok))
+}
+
+func (p *DemoGrpc) authCtx() context.Context {
+	tok := p.accessToken()
+	if tok == "" {
+		tok = "test"
+	}
+	md := metadata.Pairs("authorization", fmt.Sprintf("%s %s", "bearer", tok))
+	return mm.MD(md).ToOutgoing(context.Background())
 }
 
 func (p *DemoGrpc) sayHi(c *ishell.Context) {
@@ -65,9 +104,7 @@ func (p *DemoGrpc) sayHi(c *ishell.Context) {
 	if t != "" {
 		topic = t
 	}
-	md := metadata.Pairs("authorization", fmt.Sprintf("%s %v", "bearer", "test"))
-	ctx := mm.MD(md).ToOutgoing(context.Background())
-	if response, err := p.client.Hi(ctx, &pb.HiRequest{
+	if response, err := p.client.Hi(p.authCtx(), &pb.HiRequest{
 		Uid:     "10000",
 		Message: msg,
 		Topic:   topic,
@@ -88,9 +125,7 @@ func (p *DemoGrpc) watch(c *ishell.Context) {
 		topic = t
 	}
 
-	md := metadata.Pairs("authorization", fmt.Sprintf("%s %v", "bearer", "test"))
-	ctx := mm.MD(md).ToOutgoing(context.Background())
-	if stream, err := p.client.Watch(ctx, &pb.WatchRequest{
+	if stream, err := p.client.Watch(p.authCtx(), &pb.WatchRequest{
 		Topic: topic,
 	}); err != nil {
 		slogger.Warn(c, err)

--- a/internal/clients/game0/grpc_cli.go
+++ b/internal/clients/game0/grpc_cli.go
@@ -114,8 +114,8 @@ func (p *DemoGrpc) sayHi(c *ishell.Context) {
 	if t != "" {
 		topic = t
 	}
+	// Uid in the request is ignored by the server; auth middleware supplies UIDContextKey.
 	if response, err := p.client.Hi(ctx, &pb.HiRequest{
-		Uid:     "10000",
 		Message: msg,
 		Topic:   topic,
 	}); err != nil {

--- a/internal/clients/game0/shell.go
+++ b/internal/clients/game0/shell.go
@@ -4,20 +4,28 @@ import (
 	"net"
 
 	"github.com/abiosoft/ishell"
-
 	"github.com/gstones/moke-kit/logging/slogger"
 	"github.com/gstones/moke-kit/server/tools"
+
+	authclient "github.com/moke-game/platform/services/auth/client"
 )
 
 func RunGrpc(url string) {
 	sh := ishell.New()
 	slogger.Info(sh, "interactive game connect to "+url)
+	slogger.Info(sh, "flow: auth token <id> → game token <access> → game hi")
 
 	if conn, err := tools.DialInsecure(url); err != nil {
 		slogger.Die(sh, err)
 	} else {
 		gameGrpc := NewDemoGrpcCli(conn)
 		sh.AddCmd(gameGrpc.GetCmd())
+
+		if authCmd, err := authclient.CreateAuthClient(url); err != nil {
+			slogger.Warn(sh, err)
+		} else {
+			sh.AddCmd(authCmd)
+		}
 
 		sh.Interrupt(func(c *ishell.Context, count int, input string) {
 			if count >= 2 {

--- a/internal/clients/game0/shell.go
+++ b/internal/clients/game0/shell.go
@@ -2,6 +2,7 @@ package game0
 
 import (
 	"net"
+	"os"
 
 	"github.com/abiosoft/ishell"
 	"github.com/gstones/moke-kit/logging/slogger"
@@ -10,18 +11,38 @@ import (
 	authclient "github.com/moke-game/platform/services/auth/client"
 )
 
+// RunGrpcOptions configures the interactive gRPC shell.
+type RunGrpcOptions struct {
+	GameURL string
+	AuthURL string // if empty, falls back to GameURL (aggregate) or AUTH_URL env
+}
+
 func RunGrpc(url string) {
+	RunGrpcWithOptions(RunGrpcOptions{GameURL: url})
+}
+
+func RunGrpcWithOptions(opts RunGrpcOptions) {
 	sh := ishell.New()
-	slogger.Info(sh, "interactive game connect to "+url)
+	gameURL := opts.GameURL
+	authURL := opts.AuthURL
+	if authURL == "" {
+		authURL = os.Getenv("AUTH_URL")
+	}
+	if authURL == "" {
+		authURL = gameURL
+	}
+
+	slogger.Info(sh, "interactive game connect to "+gameURL)
+	slogger.Info(sh, "auth client connect to "+authURL)
 	slogger.Info(sh, "flow: auth token → copy access → game token → game hi")
 
-	if conn, err := tools.DialInsecure(url); err != nil {
+	if conn, err := tools.DialInsecure(gameURL); err != nil {
 		slogger.Die(sh, err)
 	} else {
 		gameGrpc := NewDemoGrpcCli(conn)
 		sh.AddCmd(gameGrpc.GetCmd())
 
-		if authCmd, err := authclient.CreateAuthClient(url); err != nil {
+		if authCmd, err := authclient.CreateAuthClient(authURL); err != nil {
 			slogger.Warn(sh, err)
 		} else {
 			sh.AddCmd(authCmd)

--- a/internal/clients/game0/shell.go
+++ b/internal/clients/game0/shell.go
@@ -13,7 +13,7 @@ import (
 func RunGrpc(url string) {
 	sh := ishell.New()
 	slogger.Info(sh, "interactive game connect to "+url)
-	slogger.Info(sh, "flow: auth token <id> → game token <access> → game hi")
+	slogger.Info(sh, "flow: auth token → copy access → game token → game hi")
 
 	if conn, err := tools.DialInsecure(url); err != nil {
 		slogger.Die(sh, err)

--- a/internal/clients/game0/shell.go
+++ b/internal/clients/game0/shell.go
@@ -17,10 +17,12 @@ type RunGrpcOptions struct {
 	AuthURL string // if empty, falls back to GameURL (aggregate) or AUTH_URL env
 }
 
+// RunGrpc starts the interactive gRPC shell against gameURL (auth defaults to same host).
 func RunGrpc(url string) {
 	RunGrpcWithOptions(RunGrpcOptions{GameURL: url})
 }
 
+// RunGrpcWithOptions starts the interactive gRPC shell with separate game/auth URLs.
 func RunGrpcWithOptions(opts RunGrpcOptions) {
 	sh := ishell.New()
 	gameURL := opts.GameURL

--- a/internal/services/game0/domain/domain.go
+++ b/internal/services/game0/domain/domain.go
@@ -68,9 +68,8 @@ func (d *Game) Hi(uid, topic, message string) error {
 }
 
 func (d *Game) Watch(ctx context.Context, topic string, callback func(message string) error) error {
-	//nats mq subscribe
 	natsTopic := common.NatsHeader.CreateTopic(topic)
-	if _, err := d.mq.Subscribe(
+	natsSub, err := d.mq.Subscribe(
 		ctx,
 		natsTopic,
 		func(msg miface.Message, err error) common.ConsumptionCode {
@@ -78,13 +77,13 @@ func (d *Game) Watch(ctx context.Context, topic string, callback func(message st
 				return common.ConsumeNackPersistentFailure
 			}
 			return common.ConsumeAck
-		}); err != nil {
+		})
+	if err != nil {
 		return err
 	}
 
-	//local(channel) mq subscribe
 	localTopic := common.LocalHeader.CreateTopic(topic)
-	if _, err := d.mq.Subscribe(
+	localSub, err := d.mq.Subscribe(
 		ctx,
 		localTopic,
 		func(msg miface.Message, err error) common.ConsumptionCode {
@@ -92,10 +91,17 @@ func (d *Game) Watch(ctx context.Context, topic string, callback func(message st
 				return common.ConsumeNackPersistentFailure
 			}
 			return common.ConsumeAck
-		}); err != nil {
+		})
+	if err != nil {
+		_ = natsSub.Unsubscribe()
 		return err
 	}
 
+	defer func() {
+		_ = natsSub.Unsubscribe()
+		_ = localSub.Unsubscribe()
+	}()
+
 	<-ctx.Done()
-	return nil
+	return ctx.Err()
 }

--- a/internal/services/game0/service.go
+++ b/internal/services/game0/service.go
@@ -32,9 +32,16 @@ type Service struct {
 	gameHandler *domain.Game
 }
 
-func (s *Service) Run(request *pb2.RunRequest, server pb2.MatchFunction_RunServer) error {
-	s.logger.Info("Run", zap.Any("request", request))
+// matchFunctionService serves Open Match MatchFunction RPCs without player auth.
+// Registered separately so AuthFuncOverride applies only to MatchFunction methods,
+// not to Game0Service (which must remain authenticated).
+type matchFunctionService struct {
+	utility.WithoutAuth
+	logger *zap.Logger
+}
 
+func (m *matchFunctionService) Run(request *pb2.RunRequest, server pb2.MatchFunction_RunServer) error {
+	m.logger.Info("MatchFunction.Run", zap.Any("request", request))
 	return nil
 }
 
@@ -80,9 +87,11 @@ func (s *Service) Hi(ctx context.Context, request *pb.HiRequest) (*pb.HiResponse
 	}, nil
 
 }
+
 func (s *Service) RegisterWithGrpcServer(server siface.IGrpcServer) error {
 	pb.RegisterGame0ServiceServer(server.GrpcServer(), s)
-	pb2.RegisterMatchFunctionServer(server.GrpcServer(), s)
+	// Open Match Backend calls MatchFunction without a player bearer token.
+	pb2.RegisterMatchFunctionServer(server.GrpcServer(), &matchFunctionService{logger: s.logger})
 	return nil
 }
 
@@ -104,7 +113,7 @@ func (s *Service) PreHandle(_ ziface.IRequest) {
 }
 
 // Handle is the zinx TCP entrypoint. It is NOT covered by gRPC AuthMiddleware;
-// only enable via TcpModule / AllWithTcpModule on trusted networks.
+// only enable via TcpModule / AllWithTCPModule on trusted networks.
 func (s *Service) Handle(request ziface.IRequest) {
 	switch request.GetMsgID() {
 	case 1:

--- a/internal/services/game0/service.go
+++ b/internal/services/game0/service.go
@@ -9,10 +9,13 @@ import (
 	"github.com/gstones/moke-kit/orm/pkg/ofx"
 	"github.com/gstones/moke-kit/server/pkg/sfx"
 	"github.com/gstones/moke-kit/server/siface"
+	"github.com/gstones/moke-kit/utility"
 	"github.com/gstones/zinx/ziface"
 	"github.com/redis/go-redis/v9"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	pb2 "open-match.dev/open-match/pkg/pb"
 
@@ -58,11 +61,15 @@ func (s *Service) Watch(request *pb.WatchRequest, server pb.Game0Service_WatchSe
 	return nil
 }
 
-func (s *Service) Hi(_ context.Context, request *pb.HiRequest) (*pb.HiResponse, error) {
+func (s *Service) Hi(ctx context.Context, request *pb.HiRequest) (*pb.HiResponse, error) {
+	uid, ok := ctx.Value(utility.UIDContextKey).(string)
+	if !ok || uid == "" {
+		return nil, status.Error(codes.Unauthenticated, "missing uid in context")
+	}
 	message := request.GetMessage()
-	s.logger.Info("Hi", zap.String("message", message))
+	s.logger.Info("Hi", zap.String("uid", uid), zap.String("message", message))
 
-	if err := s.gameHandler.Hi(request.GetUid(), request.GetTopic(), request.GetMessage()); err != nil {
+	if err := s.gameHandler.Hi(uid, request.GetTopic(), request.GetMessage()); err != nil {
 		return nil, err
 	}
 	return &pb.HiResponse{

--- a/internal/services/game0/service.go
+++ b/internal/services/game0/service.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gstones/moke-kit/orm/pkg/ofx"
 	"github.com/gstones/moke-kit/server/pkg/sfx"
 	"github.com/gstones/moke-kit/server/siface"
-	"github.com/gstones/moke-kit/utility"
 	"github.com/gstones/zinx/ziface"
 	"github.com/redis/go-redis/v9"
 	"go.uber.org/fx"
@@ -23,8 +22,9 @@ import (
 	"github.com/moke-game/game/pkg/dfx"
 )
 
+// Service is the game0 public API. Auth is enforced by platform AuthMiddlewareModule
+// (do not embed utility.WithoutAuth on public services).
 type Service struct {
-	utility.WithoutAuth
 	logger      *zap.Logger
 	gameHandler *domain.Game
 }
@@ -158,6 +158,36 @@ func NewService(
 	return
 }
 
+// ServiceModule provides one shared Service instance across gRPC, gateway, and TCP.
+var ServiceModule = fx.Provide(
+	func(
+		l *zap.Logger,
+		dProvider ofx.DocumentStoreParams,
+		setting dfx.SettingsParams,
+		mqParams mfx.MessageQueueParams,
+		redisClient ofx.RedisParams,
+	) (grpcOut sfx.GrpcServiceResult, httpOut sfx.GatewayServiceResult, tcpOut sfx.ZinxServiceResult, err error) {
+		coll, err := dProvider.DriverProvider.OpenDbDriver(setting.DbName)
+		if err != nil {
+			return
+		}
+		s, err := NewService(
+			l,
+			coll,
+			mqParams.MessageQueue,
+			redisClient.Redis,
+		)
+		if err != nil {
+			return
+		}
+		grpcOut.GrpcService = s
+		httpOut.GatewayService = s
+		tcpOut.ZinxService = s
+		return
+	},
+)
+
+// Deprecated: use ServiceModule so gRPC/HTTP/TCP share one instance.
 var GrpcService = fx.Provide(
 	func(
 		l *zap.Logger,
@@ -182,6 +212,7 @@ var GrpcService = fx.Provide(
 	},
 )
 
+// Deprecated: use ServiceModule.
 var HttpService = fx.Provide(
 	func(
 		l *zap.Logger,
@@ -206,6 +237,7 @@ var HttpService = fx.Provide(
 	},
 )
 
+// Deprecated: use ServiceModule.
 var TcpService = fx.Provide(
 	func(
 		l *zap.Logger,

--- a/internal/services/game0/service.go
+++ b/internal/services/game0/service.go
@@ -158,106 +158,48 @@ func NewService(
 	return
 }
 
-// ServiceModule provides one shared Service instance across gRPC, gateway, and TCP.
-var ServiceModule = fx.Provide(
+// ServiceInstance provides one shared *Service for transport providers below.
+var ServiceInstance = fx.Provide(
 	func(
 		l *zap.Logger,
 		dProvider ofx.DocumentStoreParams,
 		setting dfx.SettingsParams,
 		mqParams mfx.MessageQueueParams,
 		redisClient ofx.RedisParams,
-	) (grpcOut sfx.GrpcServiceResult, httpOut sfx.GatewayServiceResult, tcpOut sfx.ZinxServiceResult, err error) {
+	) (s *Service, err error) {
 		coll, err := dProvider.DriverProvider.OpenDbDriver(setting.DbName)
 		if err != nil {
-			return
+			return nil, err
 		}
-		s, err := NewService(
+		return NewService(
 			l,
 			coll,
 			mqParams.MessageQueue,
 			redisClient.Redis,
 		)
-		if err != nil {
-			return
-		}
-		grpcOut.GrpcService = s
-		httpOut.GatewayService = s
-		tcpOut.ZinxService = s
-		return
 	},
 )
 
-// Deprecated: use ServiceModule so gRPC/HTTP/TCP share one instance.
+// GrpcService registers the shared Service on the gRPC server.
 var GrpcService = fx.Provide(
-	func(
-		l *zap.Logger,
-		dProvider ofx.DocumentStoreParams,
-		setting dfx.SettingsParams,
-		mqParams mfx.MessageQueueParams,
-		redisClient ofx.RedisParams,
-	) (out sfx.GrpcServiceResult, err error) {
-		if coll, err := dProvider.DriverProvider.OpenDbDriver(setting.DbName); err != nil {
-			return out, err
-		} else if s, err := NewService(
-			l,
-			coll,
-			mqParams.MessageQueue,
-			redisClient.Redis,
-		); err != nil {
-			return out, err
-		} else {
-			out.GrpcService = s
-		}
+	func(s *Service) (out sfx.GrpcServiceResult, err error) {
+		out.GrpcService = s
 		return
 	},
 )
 
-// Deprecated: use ServiceModule.
+// HttpService registers the shared Service on the HTTP gateway.
 var HttpService = fx.Provide(
-	func(
-		l *zap.Logger,
-		dProvider ofx.DocumentStoreParams,
-		setting dfx.SettingsParams,
-		mqParams mfx.MessageQueueParams,
-		redisClient ofx.RedisParams,
-	) (out sfx.GatewayServiceResult, err error) {
-		if coll, err := dProvider.DriverProvider.OpenDbDriver(setting.DbName); err != nil {
-			return out, err
-		} else if s, err := NewService(
-			l,
-			coll,
-			mqParams.MessageQueue,
-			redisClient.Redis,
-		); err != nil {
-			return out, err
-		} else {
-			out.GatewayService = s
-		}
+	func(s *Service) (out sfx.GatewayServiceResult, err error) {
+		out.GatewayService = s
 		return
 	},
 )
 
-// Deprecated: use ServiceModule.
+// TcpService registers the shared Service on the TCP (zinx) server.
 var TcpService = fx.Provide(
-	func(
-		l *zap.Logger,
-		dProvider ofx.DocumentStoreParams,
-		setting dfx.SettingsParams,
-		mqParams mfx.MessageQueueParams,
-		redisClient ofx.RedisParams,
-	) (out sfx.ZinxServiceResult, err error) {
-		if coll, err := dProvider.DriverProvider.OpenDbDriver(setting.DbName); err != nil {
-			return out, err
-		} else if s, err := NewService(
-			l,
-			coll,
-			mqParams.MessageQueue,
-			redisClient.Redis,
-		); err != nil {
-			return out, err
-		} else {
-			out.ZinxService = s
-		}
+	func(s *Service) (out sfx.ZinxServiceResult, err error) {
+		out.ZinxService = s
 		return
 	},
 )

--- a/internal/services/game0/service.go
+++ b/internal/services/game0/service.go
@@ -40,6 +40,7 @@ func (s *Service) Run(request *pb2.RunRequest, server pb2.MatchFunction_RunServe
 
 // ---------------- grpc ----------------
 
+// Watch streams topic messages for an authenticated caller.
 func (s *Service) Watch(request *pb.WatchRequest, server pb.Game0Service_WatchServer) error {
 	topic := request.GetTopic()
 	s.logger.Info("Watch", zap.String("topic", topic))
@@ -61,6 +62,8 @@ func (s *Service) Watch(request *pb.WatchRequest, server pb.Game0Service_WatchSe
 	return nil
 }
 
+// Hi handles the authenticated hello RPC. UID comes from auth middleware context,
+// not from the request payload (avoids uid spoofing).
 func (s *Service) Hi(ctx context.Context, request *pb.HiRequest) (*pb.HiResponse, error) {
 	uid, ok := ctx.Value(utility.UIDContextKey).(string)
 	if !ok || uid == "" {
@@ -100,6 +103,8 @@ func (s *Service) PreHandle(_ ziface.IRequest) {
 
 }
 
+// Handle is the zinx TCP entrypoint. It is NOT covered by gRPC AuthMiddleware;
+// only enable via TcpModule / AllWithTcpModule on trusted networks.
 func (s *Service) Handle(request ziface.IRequest) {
 	switch request.GetMsgID() {
 	case 1:
@@ -107,6 +112,8 @@ func (s *Service) Handle(request ziface.IRequest) {
 		if err := proto.Unmarshal(request.GetData(), req); err != nil {
 			s.logger.Error("unmarshal request data error", zap.Error(err))
 		} else {
+			s.logger.Warn("tcp Hi has no auth; uid taken from payload (demo only)",
+				zap.String("uid", req.GetUid()))
 			if err := s.gameHandler.Hi(req.GetUid(), req.GetTopic(), req.GetMessage()); err != nil {
 				s.logger.Error("Hi error", zap.Error(err))
 			}

--- a/pkg/dfx/auth.go
+++ b/pkg/dfx/auth.go
@@ -14,13 +14,14 @@ import (
 // Author is an optional custom auth middleware example.
 //
 // Default wiring uses platform AuthMiddlewareModule (ValidateToken) via
-// pkg/modules.AllModule — do not enable CustomAuthModule unless you intentionally
+// cmd mains — do not enable CustomAuthModule unless you intentionally
 // replace that middleware (both export name:"AuthMiddleware").
+// CustomAuthModule does NOT validate tokens; it only extracts the bearer.
 type Author struct {
 	unAuthMethods map[string]struct{}
 }
 
-// Auth extracts the bearer token. Replace the TODO body if you use CustomAuthModule.
+// Auth extracts the bearer token. Replace the body if you use CustomAuthModule.
 func (d *Author) Auth(ctx context.Context) (context.Context, error) {
 	method, _ := grpc.Method(ctx)
 	if _, ok := d.unAuthMethods[method]; ok {
@@ -44,7 +45,7 @@ func (d *Author) AddUnAuthMethod(method string) {
 }
 
 // CustomAuthModule is an optional stub middleware for experiments only.
-// Production/templates should use:
+// It does not call ValidateToken. Production/templates should use:
 //
 //	auth "github.com/moke-game/platform/services/auth/pkg/module"
 //	auth.AuthMiddlewareModule
@@ -58,7 +59,3 @@ var CustomAuthModule = fx.Provide(
 		return
 	},
 )
-
-// AuthModule is kept as an alias so older references compile, but it is not
-// used by AllModule anymore. Prefer platform AuthMiddlewareModule.
-var AuthModule = CustomAuthModule

--- a/pkg/dfx/auth.go
+++ b/pkg/dfx/auth.go
@@ -11,12 +11,16 @@ import (
 	"google.golang.org/grpc"
 )
 
-// Author is a game auth service
+// Author is an optional custom auth middleware example.
+//
+// Default wiring uses platform AuthMiddlewareModule (ValidateToken) via
+// pkg/modules.AllModule — do not enable CustomAuthModule unless you intentionally
+// replace that middleware (both export name:"AuthMiddleware").
 type Author struct {
 	unAuthMethods map[string]struct{}
 }
 
-// Auth is a game auth method
+// Auth extracts the bearer token. Replace the TODO body if you use CustomAuthModule.
 func (d *Author) Auth(ctx context.Context) (context.Context, error) {
 	method, _ := grpc.Method(ctx)
 	if _, ok := d.unAuthMethods[method]; ok {
@@ -26,15 +30,12 @@ func (d *Author) Auth(ctx context.Context) (context.Context, error) {
 	if err != nil {
 		return ctx, err
 	}
-	// TODO check token with your custom auth middleware
-	//CheckToken(token)
+	// Custom deployments: validate token here (or prefer platform AuthMiddlewareModule).
 	_ = token
 	return ctx, nil
 }
 
-//AddUnAuthMethod(method string)
-
-// AddUnAuthMethod add you want to disable auth method here
+// AddUnAuthMethod marks a full method name as unauthenticated.
 func (d *Author) AddUnAuthMethod(method string) {
 	if d.unAuthMethods == nil {
 		d.unAuthMethods = make(map[string]struct{})
@@ -42,17 +43,12 @@ func (d *Author) AddUnAuthMethod(method string) {
 	d.unAuthMethods[method] = struct{}{}
 }
 
-// AuthModule is a game auth module
-// you can implement your own auth service or auth function
-// Auth will check every rpc/http request,
-// if you want to disable it for a service, add `utility.WithoutAuth` in struct of your service
+// CustomAuthModule is an optional stub middleware for experiments only.
+// Production/templates should use:
 //
-//	type service struct {
-//		utility.WithoutAuth
-//	}
-//
-// or disable it for a method, add the method name by `AddUnAuthMethod`
-var AuthModule = fx.Provide(
+//	auth "github.com/moke-game/platform/services/auth/pkg/module"
+//	auth.AuthMiddlewareModule
+var CustomAuthModule = fx.Provide(
 	func(
 		l *zap.Logger,
 	) (out sfx.AuthMiddlewareResult, err error) {
@@ -62,3 +58,7 @@ var AuthModule = fx.Provide(
 		return
 	},
 )
+
+// AuthModule is kept as an alias so older references compile, but it is not
+// used by AllModule anymore. Prefer platform AuthMiddlewareModule.
+var AuthModule = CustomAuthModule

--- a/pkg/modules/game0_module.go
+++ b/pkg/modules/game0_module.go
@@ -3,47 +3,41 @@ package modules
 import (
 	"go.uber.org/fx"
 
-	"github.com/moke-game/game/internal/services/game0"
+	auth "github.com/moke-game/platform/services/auth/pkg/module"
 
+	"github.com/moke-game/game/internal/services/game0"
 	"github.com/moke-game/game/pkg/dfx"
 )
 
-// GrpcModule  grpc service module
-// can inject it to any fxmain.Main(), if you want to start a game grpc service
+// GrpcModule starts game gRPC with platform AuthMiddlewareModule by default.
 var GrpcModule = fx.Module("grpcService",
 	dfx.SettingsModule,
-	dfx.AuthModule,
-	game0.GrpcService,
+	auth.AuthMiddlewareModule,
+	game0.ServiceModule,
 )
 
-// HttpModule  http service module
-// can inject it to any fxmain.Main(), if you want to start a game http service
+// HttpModule starts game gRPC + HTTP gateway with AuthMiddlewareModule.
 var HttpModule = fx.Module("httpService",
 	dfx.SettingsModule,
-	dfx.AuthModule,
-	game0.GrpcService,
-	game0.HttpService,
+	auth.AuthMiddlewareModule,
+	game0.ServiceModule,
 )
 
-// TcpModule  tcp service module
-// can inject it to any fxmain.Main(), if you want to start a game tcp service
+// TcpModule starts game TCP (zinx) service.
 var TcpModule = fx.Module("tcpService",
 	dfx.SettingsModule,
-	game0.TcpService,
+	game0.ServiceModule,
 )
 
-// AllModule  all service module
-// can inject it to any fxmain.Main(), if you want to start game all type services
+// AllModule starts all game transports.
+// Pair with platform auth.AuthMiddlewareModule (thin) or auth.AuthAllModule
+// (aggregate) in main — do not embed auth here to avoid duplicate providers.
 var AllModule = fx.Module("allService",
-	//dfx.AuthModule,
 	dfx.SettingsModule,
-	game0.GrpcService,
-	game0.HttpService,
-	game0.TcpService,
+	game0.ServiceModule,
 )
 
-// GrpcClientModule  grpc client module
-// can inject it to any fxmain.Main(), if you want a game grpc client to rpc game service
+// GrpcClientModule provides a game gRPC client.
 var GrpcClientModule = fx.Module("grpcClient",
 	dfx.SettingsModule,
 	dfx.Game0ClientModule,

--- a/pkg/modules/game0_module.go
+++ b/pkg/modules/game0_module.go
@@ -37,7 +37,7 @@ var TcpModule = fx.Module("tcpService",
 )
 
 // AllModule starts authenticated game transports (gRPC + HTTP gateway).
-// TCP is intentionally omitted — use TcpModule / AllWithTcpModule only for
+// TCP is intentionally omitted — use TcpModule / AllWithTCPModule only for
 // trusted local demos. Pair with auth.AuthMiddlewareModule (thin) or
 // auth.AuthAllModule (aggregate) in main.
 var AllModule = fx.Module("allService",
@@ -47,9 +47,9 @@ var AllModule = fx.Module("allService",
 	game0.HttpService,
 )
 
-// AllWithTcpModule is AllModule plus unauthenticated TCP (zinx).
+// AllWithTCPModule is AllModule plus unauthenticated TCP (zinx).
 // Do not use on public networks.
-var AllWithTcpModule = fx.Module("allServiceWithTcp",
+var AllWithTCPModule = fx.Module("allServiceWithTcp",
 	dfx.SettingsModule,
 	game0.ServiceInstance,
 	game0.GrpcService,

--- a/pkg/modules/game0_module.go
+++ b/pkg/modules/game0_module.go
@@ -9,32 +9,40 @@ import (
 	"github.com/moke-game/game/pkg/dfx"
 )
 
-// GrpcModule starts game gRPC with platform AuthMiddlewareModule by default.
+// GrpcModule starts game gRPC only, with platform AuthMiddlewareModule.
 var GrpcModule = fx.Module("grpcService",
 	dfx.SettingsModule,
 	auth.AuthMiddlewareModule,
-	game0.ServiceModule,
+	game0.ServiceInstance,
+	game0.GrpcService,
 )
 
 // HttpModule starts game gRPC + HTTP gateway with AuthMiddlewareModule.
 var HttpModule = fx.Module("httpService",
 	dfx.SettingsModule,
 	auth.AuthMiddlewareModule,
-	game0.ServiceModule,
+	game0.ServiceInstance,
+	game0.GrpcService,
+	game0.HttpService,
 )
 
-// TcpModule starts game TCP (zinx) service.
+// TcpModule starts game TCP (zinx) only.
+// Note: zinx does not use gRPC AuthMiddleware; protect at network edge if needed.
 var TcpModule = fx.Module("tcpService",
 	dfx.SettingsModule,
-	game0.ServiceModule,
+	game0.ServiceInstance,
+	game0.TcpService,
 )
 
-// AllModule starts all game transports.
+// AllModule starts all game transports (shared Service instance).
 // Pair with platform auth.AuthMiddlewareModule (thin) or auth.AuthAllModule
 // (aggregate) in main — do not embed auth here to avoid duplicate providers.
 var AllModule = fx.Module("allService",
 	dfx.SettingsModule,
-	game0.ServiceModule,
+	game0.ServiceInstance,
+	game0.GrpcService,
+	game0.HttpService,
+	game0.TcpService,
 )
 
 // GrpcClientModule provides a game gRPC client.

--- a/pkg/modules/game0_module.go
+++ b/pkg/modules/game0_module.go
@@ -27,17 +27,29 @@ var HttpModule = fx.Module("httpService",
 )
 
 // TcpModule starts game TCP (zinx) only.
-// Note: zinx does not use gRPC AuthMiddleware; protect at network edge if needed.
+//
+// WARNING: zinx does not use gRPC AuthMiddleware. Callers can spoof uid.
+// Opt-in for local experiments only; keep off the public network.
 var TcpModule = fx.Module("tcpService",
 	dfx.SettingsModule,
 	game0.ServiceInstance,
 	game0.TcpService,
 )
 
-// AllModule starts all game transports (shared Service instance).
-// Pair with platform auth.AuthMiddlewareModule (thin) or auth.AuthAllModule
-// (aggregate) in main — do not embed auth here to avoid duplicate providers.
+// AllModule starts authenticated game transports (gRPC + HTTP gateway).
+// TCP is intentionally omitted — use TcpModule / AllWithTcpModule only for
+// trusted local demos. Pair with auth.AuthMiddlewareModule (thin) or
+// auth.AuthAllModule (aggregate) in main.
 var AllModule = fx.Module("allService",
+	dfx.SettingsModule,
+	game0.ServiceInstance,
+	game0.GrpcService,
+	game0.HttpService,
+)
+
+// AllWithTcpModule is AllModule plus unauthenticated TCP (zinx).
+// Do not use on public networks.
+var AllWithTcpModule = fx.Module("allServiceWithTcp",
 	dfx.SettingsModule,
 	game0.ServiceInstance,
 	game0.GrpcService,

--- a/tests/game0/auth-k6.proto
+++ b/tests/game0/auth-k6.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+
+package auth.v1;
+option go_package = "auth/api/;v1";
+
+service AuthService {
+  rpc Authenticate (AuthenticateRequest) returns (AuthenticateResponse) {};
+  rpc ValidateToken (ValidateTokenRequest) returns (ValidateTokenResponse) {};
+}
+
+message AuthenticateRequest {
+  string app_id = 1;
+  string id = 2;
+}
+
+message AuthenticateResponse {
+  string access_token = 1;
+  string refresh_token = 2;
+  string uid = 3;
+  bool is_override = 4;
+}
+
+message ValidateTokenRequest {
+  string access_token = 1;
+}
+
+message ValidateTokenResponse {
+  string uid = 1;
+  bytes custom_data = 2;
+}

--- a/tests/game0/game0-k6.proto
+++ b/tests/game0/game0-k6.proto
@@ -1,9 +1,9 @@
 syntax = "proto3";
 
-package game.pb;
-option go_package = "game/api;pb";
+package game0.pb;
+option go_package = "game0/api;pb";
 
-service DemoService {
+service Game0Service {
   rpc Hi (HiRequest) returns (HiResponse) {};
   rpc Watch(WatchRequest) returns (stream WatchResponse) {};
 }
@@ -11,6 +11,7 @@ service DemoService {
 message HiRequest {
   string uid = 1;
   string message = 2;
+  string topic = 3;
 }
 
 message HiResponse {

--- a/tests/game0/game0.js
+++ b/tests/game0/game0.js
@@ -5,12 +5,15 @@ import {makeParams} from "../common/common.js";
 const client = new Client();
 client.load(['./'], 'game0-k6.proto', 'auth-k6.proto');
 
+// Aggregate: AUTH_HOST can equal SERVER_HOST (in-process AuthService).
+// Thin: set AUTH_HOST to the remote AuthService (e.g. 127.0.0.1:8082).
 const GRPC_ADDR = __ENV.SERVER_HOST || '127.0.0.1:8081';
+const AUTH_ADDR = __ENV.AUTH_HOST || GRPC_ADDR;
 const AUTH_ID = __ENV.AUTH_ID || 'k6-user';
 const APP_ID = __ENV.APP_ID || 'test';
 
 export function setup() {
-    client.connect(GRPC_ADDR, {plaintext: true});
+    client.connect(AUTH_ADDR, {plaintext: true});
     const authResp = client.invoke('auth.v1.AuthService/Authenticate', {
         id: AUTH_ID,
         app_id: APP_ID,
@@ -21,7 +24,7 @@ export function setup() {
     const token = authResp.message && (authResp.message.accessToken || authResp.message.access_token);
     client.close();
     if (!token) {
-        throw new Error('Authenticate did not return access_token');
+        throw new Error('Authenticate did not return access_token (check AUTH_HOST for thin topology)');
     }
     return {token};
 }
@@ -31,7 +34,6 @@ export default function (data) {
         plaintext: true
     });
     const payload = {
-        uid: AUTH_ID,
         message: 'hello',
         topic: 'game',
     };

--- a/tests/game0/game0.js
+++ b/tests/game0/game0.js
@@ -3,20 +3,40 @@ import {check, sleep} from 'k6';
 import {makeParams} from "../common/common.js";
 
 const client = new Client();
-client.load(['./'], 'game-k6.proto');
+client.load(['./'], 'game0-k6.proto', 'auth-k6.proto');
 
 const GRPC_ADDR = __ENV.SERVER_HOST || '127.0.0.1:8081';
+const AUTH_ID = __ENV.AUTH_ID || 'k6-user';
+const APP_ID = __ENV.APP_ID || 'test';
 
-export default function () {
+export function setup() {
+    client.connect(GRPC_ADDR, {plaintext: true});
+    const authResp = client.invoke('auth.v1.AuthService/Authenticate', {
+        id: AUTH_ID,
+        app_id: APP_ID,
+    });
+    check(authResp, {
+        'authenticate ok': (r) => r && r.status === StatusOK,
+    });
+    const token = authResp.message && (authResp.message.accessToken || authResp.message.access_token);
+    client.close();
+    if (!token) {
+        throw new Error('Authenticate did not return access_token');
+    }
+    return {token};
+}
+
+export default function (data) {
     client.connect(GRPC_ADDR, {
         plaintext: true
     });
-    const data = {
-        uid: 'test',
+    const payload = {
+        uid: AUTH_ID,
         message: 'hello',
+        topic: 'game',
     };
-    const params = makeParams("test");
-    let response = client.invoke('game.pb.DemoService/Hi', data,params);
+    const params = makeParams(data.token);
+    const response = client.invoke('game0.pb.Game0Service/Hi', payload, params);
     console.log(response);
     check(response, {
         'status is OK': (r) => r && r.status === StatusOK,
@@ -24,5 +44,3 @@ export default function () {
     client.close();
     sleep(1);
 }
-
-


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Implements [game#18](https://github.com/moke-game/game/issues/18) on [platform#24](https://github.com/moke-game/platform/pull/24) / moke-kit #221.

### Secure defaults
- Remove `WithoutAuth` from public `Game0Service`; platform auth middleware by default
- `Hi` uses `UIDContextKey` (no request-uid spoofing)
- Open Match `MatchFunction` registered on a separate `WithoutAuth` type (Backend has no player token)
- `AllModule` = gRPC + HTTP only; TCP opt-in via `TcpModule` / `AllWithTCPModule`
- CLI `--auth-host` / `AUTH_URL`; k6 `AUTH_HOST` for thin

### Topology
- Aggregate + `service-thin`
- Shared `ServiceInstance` with per-transport providers
- Watch retains/cancels MQ subscriptions

### Depends on
- https://github.com/moke-game/platform/pull/24 (`a795720`)

### Test plan
- [x] `go build` aggregate / thin / client
- [ ] Aggregate: auth token → game token → hi; MatchFunction reachable without bearer
- [ ] Thin: `AUTH_HOST` + `--auth-host`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-398a3149-3eb1-4944-b716-74b5ecd93293?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-398a3149-3eb1-4944-b716-74b5ecd93293&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

