### PR TITLE
chore: pin platform to #25 merge on main

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,10 @@
+# Compatibility
+
+| Dependency | Version | Notes |
+|------------|---------|-------|
+| moke-kit | `v1.0.5-0.20260811094419-bcdfe55515cd` (#224) | Binder fail-closed; create-game templates via [#226](https://github.com/GStones/moke-kit/pull/226) |
+| platform | `v0.0.0-20260811134726-fcdebd60c4df` ([#25](https://github.com/moke-game/platform/pull/25) on `main`) | Auth contracts, messaging docs, chat Destroy |
+
+Validated by [game#19](https://github.com/moke-game/game/pull/19) (auth dual topology) and [game#20](https://github.com/moke-game/game/pull/20) (kit/platform bump).
+
+Tracking: https://github.com/moke-game/game/issues/18

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0
 	github.com/gstones/moke-kit v1.0.5-0.20260811094419-bcdfe55515cd
 	github.com/gstones/zinx v1.2.7-0.20240617071724-88bd884d8d08
-	github.com/moke-game/platform v0.0.0-20260811134209-1fe973532f5a
+	github.com/moke-game/platform v0.0.0-20260811134726-fcdebd60c4df
 	github.com/redis/go-redis/v9 v9.7.3
 	github.com/spf13/cobra v1.9.1
 	go.uber.org/fx v1.23.0

--- a/go.sum
+++ b/go.sum
@@ -207,8 +207,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/moke-game/platform v0.0.0-20260811134209-1fe973532f5a h1:iNUnh2ThFONkNs5A5D9ast5VPOuuCoHhqX4Y4ea2su8=
-github.com/moke-game/platform v0.0.0-20260811134209-1fe973532f5a/go.mod h1:PSi9NIhg0+rFvxG7dLT6L2fdwiOS6SjsPjc0qs+QbKs=
+github.com/moke-game/platform v0.0.0-20260811134726-fcdebd60c4df h1:Tp0+vzlrWpN2vWRkq3H08xp8IOUSEj69XLXnIagViZE=
+github.com/moke-game/platform v0.0.0-20260811134726-fcdebd60c4df/go.mod h1:PSi9NIhg0+rFvxG7dLT6L2fdwiOS6SjsPjc0qs+QbKs=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=
 github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
After [#20](https://github.com/moke-game/game/pull/20) / [#25](https://github.com/moke-game/platform/pull/25) merged, retarget the platform module pin from the PR tip to the merge commit on `main`.

### Changes
- `github.com/moke-game/platform` → `v0.0.0-20260811134726-fcdebd60c4df`
- Add `COMPATIBILITY.md`

### Test plan
- [x] `go build ./...`
- [ ] CI green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-398a3149-3eb1-4944-b716-74b5ecd93293?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-398a3149-3eb1-4944-b716-74b5ecd93293&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

