### PR TITLE
feat: bump kit#228/platform tip, auth-free modules, Watch tests

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -2,7 +2,7 @@
 
 ## Auth topology
 - Public game APIs must not embed `utility.WithoutAuth`.
-- `AllModule` has no auth provider — pair `AuthAllModule` (aggregate) or `AuthMiddlewareModule` (thin) in `main`, never both with a stub.
+- `GrpcModule` / `HttpModule` / `AllModule` have no auth provider — pair `AuthAllModule` (aggregate) or `AuthMiddlewareModule` (thin) in `main`, never both with a stub.
 - Flag handlers that trust `request.uid` instead of `UIDContextKey`.
 - MatchFunction / Open Match callbacks may be WithoutAuth — flag if that type is reused for player-facing RPCs.
 

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -17,9 +17,9 @@ jobs:
         with:
           against: "https://github.com/${{ github.repository }}.git#branch=main,ref=HEAD~1"
 
-      # BSR push requires a valid BUF_TOKEN secret. Keep non-blocking until rotated.
+      # Skip when BUF_TOKEN is unset; fail hard when present but invalid.
       - name: Push module to BSR
-        continue-on-error: true
+        if: ${{ secrets.BUF_TOKEN != '' }}
         uses: bufbuild/buf-push-action@v1
         with:
           buf_token: ${{ secrets.BUF_TOKEN }}

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -2,9 +2,9 @@
 
 | Dependency | Version | Notes |
 |------------|---------|-------|
-| moke-kit | `v1.0.5-0.20260811094419-bcdfe55515cd` (#224); tip [#228](https://github.com/GStones/moke-kit/pull/228) on kit `main` | Binder fail-closed; StopServing/CAS/CI on tip |
-| platform | `v0.0.0-20260812022153-40241b2322e3` ([#27](https://github.com/moke-game/platform/pull/27) on `main`) | jwt/v5, CAS/chat lifecycle tests, CI lint/vuln |
+| moke-kit | `v1.0.5-0.20260812022140-acb9f313d7fd` ([#228](https://github.com/GStones/moke-kit/pull/228)) | Binder fail-closed + StopServing/CAS/CI |
+| platform | tip `1753fc96…` (kit #228 bump + prod JWT expire guard) | Depends on [platform PR](https://github.com/moke-game/platform/compare/main...cursor/issue-23-kit228-jwt-buf-3293) |
 
-Validated by [game#22](https://github.com/moke-game/game/pull/22). This PR retargets the platform pin from the #27 tip to the merge commit on `main`.
+`GrpcModule` / `HttpModule` / `AllModule` do not embed auth — pair `AuthAllModule` (aggregate) or `AuthMiddlewareModule` (thin) in `main`.
 
 Tracking: https://github.com/moke-game/game/issues/18

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/abiosoft/ishell v2.0.0+incompatible
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.1
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0
-	github.com/gstones/moke-kit v1.0.5-0.20260811094419-bcdfe55515cd
+	github.com/gstones/moke-kit v1.0.5-0.20260812022140-acb9f313d7fd
 	github.com/gstones/zinx v1.2.7-0.20240617071724-88bd884d8d08
-	github.com/moke-game/platform v0.0.0-20260812022153-40241b2322e3
+	github.com/moke-game/platform v0.0.0-20260812024114-1753fc966873
 	github.com/redis/go-redis/v9 v9.7.3
 	github.com/spf13/cobra v1.9.1
 	go.uber.org/fx v1.23.0

--- a/go.sum
+++ b/go.sum
@@ -139,8 +139,8 @@ github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.1 h1:KcFzXwzM/kGhIRHvc8jdix
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.1/go.mod h1:qOchhhIlmRcqk/O9uCo/puJlyo07YINaIqdZfZG3Jkc=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz+PMpZ14Jynv3O2Zs=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0/go.mod h1:JfhWUomR1baixubs02l85lZYYOm7LV6om4ceouMv45c=
-github.com/gstones/moke-kit v1.0.5-0.20260811094419-bcdfe55515cd h1:Wjoql7CGC37RqOd7cuvWaIfY3+nLQggihqoZVRLnju0=
-github.com/gstones/moke-kit v1.0.5-0.20260811094419-bcdfe55515cd/go.mod h1:v/VZdvZ2wSit8B4plZBJ8nzBJFlZNQ1X6vI0jdfQJFU=
+github.com/gstones/moke-kit v1.0.5-0.20260812022140-acb9f313d7fd h1:0lklTFcnbZt771O4WEanbdyqomi4b6fWMt/A04dEYMo=
+github.com/gstones/moke-kit v1.0.5-0.20260812022140-acb9f313d7fd/go.mod h1:v/VZdvZ2wSit8B4plZBJ8nzBJFlZNQ1X6vI0jdfQJFU=
 github.com/gstones/zinx v1.2.7-0.20240617071724-88bd884d8d08 h1:YjrnGjuIRVs2t0MjMs4DFQox9GH/4jlOELMRVD5d+xg=
 github.com/gstones/zinx v1.2.7-0.20240617071724-88bd884d8d08/go.mod h1:tgm/iZBMyKKZj4totfeu4+PMzSLb4JH8pnGdcG3ql+8=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -209,8 +209,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/moke-game/platform v0.0.0-20260812022153-40241b2322e3 h1:CN0hRDvUC0iHyqGDH7mflIxLApI2/Z50N5cyEz7V8rw=
-github.com/moke-game/platform v0.0.0-20260812022153-40241b2322e3/go.mod h1:ckqWe5JgHWISyEc90r/+FM9VKGlQKitluSmo6Wv3f1M=
+github.com/moke-game/platform v0.0.0-20260812024114-1753fc966873 h1:itzk/K/3EmzBuVat1isSU/RsoLQ4Ns1IoeyblUoxo88=
+github.com/moke-game/platform v0.0.0-20260812024114-1753fc966873/go.mod h1:3AxGi1ycrKQwLE13WX8ADsQlMrTO3gyf60hs+pZliis=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=
 github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=

--- a/internal/services/game0/domain/watch_test.go
+++ b/internal/services/game0/domain/watch_test.go
@@ -1,0 +1,99 @@
+package domain
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gstones/moke-kit/mq/miface"
+	"go.uber.org/zap"
+
+	"github.com/moke-game/game/internal/services/game0/db_nosql"
+)
+
+type fakeSub struct {
+	calls *atomic.Int32
+}
+
+func (f *fakeSub) IsValid() bool { return true }
+func (f *fakeSub) Unsubscribe() error {
+	if f.calls != nil {
+		f.calls.Add(1)
+	}
+	return nil
+}
+
+type fakeMQ struct {
+	subs  int32
+	calls *atomic.Int32
+	errOn int32 // 1-based subscribe call that fails; 0 = never
+	err   error
+}
+
+func (f *fakeMQ) Subscribe(context.Context, string, miface.SubResponseHandler, ...miface.SubOption) (miface.Subscription, error) {
+	n := atomic.AddInt32(&f.subs, 1)
+	if f.errOn > 0 && n == f.errOn {
+		if f.err != nil {
+			return nil, f.err
+		}
+		return nil, errors.New("subscribe failed")
+	}
+	return &fakeSub{calls: f.calls}, nil
+}
+func (f *fakeMQ) Publish(string, ...miface.PubOption) error { return nil }
+
+func TestWatchUnsubscribesOnCancel(t *testing.T) {
+	t.Parallel()
+
+	var unsubs atomic.Int32
+	mq := &fakeMQ{calls: &unsubs}
+	g := NewGame(zap.NewNop(), db_nosql.Database{}, mq, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- g.Watch(ctx, "room-1", func(string) error { return nil })
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if atomic.LoadInt32(&mq.subs) >= 2 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if atomic.LoadInt32(&mq.subs) < 2 {
+		t.Fatalf("expected 2 subscriptions, got %d", mq.subs)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != context.Canceled {
+			t.Fatalf("Watch returned %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Watch did not return after cancel")
+	}
+
+	if got := unsubs.Load(); got != 2 {
+		t.Fatalf("Unsubscribe calls = %d, want 2", got)
+	}
+}
+
+func TestWatchCleansNatsSubWhenLocalSubscribeFails(t *testing.T) {
+	t.Parallel()
+
+	var unsubs atomic.Int32
+	mq := &fakeMQ{calls: &unsubs, errOn: 2}
+	g := NewGame(zap.NewNop(), db_nosql.Database{}, mq, nil)
+	err := g.Watch(context.Background(), "room-2", func(string) error { return nil })
+	if err == nil {
+		t.Fatal("expected local subscribe failure")
+	}
+	if got := unsubs.Load(); got != 1 {
+		t.Fatalf("Unsubscribe calls = %d, want 1 (nats cleanup)", got)
+	}
+}

--- a/pkg/modules/game0_module.go
+++ b/pkg/modules/game0_module.go
@@ -3,24 +3,22 @@ package modules
 import (
 	"go.uber.org/fx"
 
-	auth "github.com/moke-game/platform/services/auth/pkg/module"
-
 	"github.com/moke-game/game/internal/services/game0"
 	"github.com/moke-game/game/pkg/dfx"
 )
 
-// GrpcModule starts game gRPC only, with platform AuthMiddlewareModule.
+// GrpcModule starts game gRPC only.
+// Auth is not included — pair auth.AuthMiddlewareModule or auth.AuthAllModule in main.
 var GrpcModule = fx.Module("grpcService",
 	dfx.SettingsModule,
-	auth.AuthMiddlewareModule,
 	game0.ServiceInstance,
 	game0.GrpcService,
 )
 
-// HttpModule starts game gRPC + HTTP gateway with AuthMiddlewareModule.
+// HttpModule starts game gRPC + HTTP gateway.
+// Auth is not included — pair auth in main the same way as GrpcModule / AllModule.
 var HttpModule = fx.Module("httpService",
 	dfx.SettingsModule,
-	auth.AuthMiddlewareModule,
 	game0.ServiceInstance,
 	game0.GrpcService,
 	game0.HttpService,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Continues [game#18](https://github.com/moke-game/game/issues/18) after #22 / #23.

### Changes
- Bump `moke-kit` to `#228` and platform tip with prod JWT expire guard
- Remove embedded `AuthMiddlewareModule` from `GrpcModule` / `HttpModule` (auth only in `main`)
- Add `Watch` cancel/unsubscribe unit tests
- `buf-push`: skip when `BUF_TOKEN` unset
- Refresh `COMPATIBILITY.md` + Bugbot auth-topology note

### Depends on
Merge [platform kit#228 bump](https://github.com/moke-game/platform/compare/main...cursor/issue-23-kit228-jwt-buf-3293) first (or retarget pin to its merge commit).

### Test plan
- [x] `go test ./internal/services/game0/domain/ -count=1`
- [x] `go build ./...`
- [ ] CI green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-398a3149-3eb1-4944-b716-74b5ecd93293?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-398a3149-3eb1-4944-b716-74b5ecd93293&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

