### PR TITLE
chore: pin platform to #28 merge on main

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -2,9 +2,11 @@
 
 | Dependency | Version | Notes |
 |------------|---------|-------|
-| moke-kit | `v1.0.5-0.20260812022140-acb9f313d7fd` ([#228](https://github.com/GStones/moke-kit/pull/228)) | Binder fail-closed + StopServing/CAS/CI |
-| platform | tip `1753fc96…` (kit #228 bump + prod JWT expire guard) | Depends on [platform PR](https://github.com/moke-game/platform/compare/main...cursor/issue-23-kit228-jwt-buf-3293) |
+| moke-kit | `v1.0.5-0.20260812022140-acb9f313d7fd` ([#228](https://github.com/GStones/moke-kit/pull/228)); create-game tip [#229](https://github.com/GStones/moke-kit/pull/229) | Binder fail-closed + StopServing/CAS/CI; scaffold thin/auth-free modules |
+| platform | `v0.0.0-20260812031638-1fe842e07c0c` ([#28](https://github.com/moke-game/platform/pull/28) on `main`) | kit #228 + prod JWT expire guard + buf-push gate |
 
 `GrpcModule` / `HttpModule` / `AllModule` do not embed auth — pair `AuthAllModule` (aggregate) or `AuthMiddlewareModule` (thin) in `main`.
+
+Validated by [game#24](https://github.com/moke-game/game/pull/24). This PR retargets the platform pin from the #28 tip to the merge commit on `main`.
 
 Tracking: https://github.com/moke-game/game/issues/18

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0
 	github.com/gstones/moke-kit v1.0.5-0.20260812022140-acb9f313d7fd
 	github.com/gstones/zinx v1.2.7-0.20240617071724-88bd884d8d08
-	github.com/moke-game/platform v0.0.0-20260812024114-1753fc966873
+	github.com/moke-game/platform v0.0.0-20260812031638-1fe842e07c0c
 	github.com/redis/go-redis/v9 v9.7.3
 	github.com/spf13/cobra v1.9.1
 	go.uber.org/fx v1.23.0

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/moke-game/platform v0.0.0-20260812024114-1753fc966873 h1:itzk/K/3EmzBuVat1isSU/RsoLQ4Ns1IoeyblUoxo88=
-github.com/moke-game/platform v0.0.0-20260812024114-1753fc966873/go.mod h1:3AxGi1ycrKQwLE13WX8ADsQlMrTO3gyf60hs+pZliis=
+github.com/moke-game/platform v0.0.0-20260812031638-1fe842e07c0c h1:kJFrG6vHvahA4Yt3a9UZ1I5CVnRV/VOTnADFLT+yEyY=
+github.com/moke-game/platform v0.0.0-20260812031638-1fe842e07c0c/go.mod h1:3AxGi1ycrKQwLE13WX8ADsQlMrTO3gyf60hs+pZliis=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=
 github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
After [#24](https://github.com/moke-game/game/pull/24) / [#28](https://github.com/moke-game/platform/pull/28) merged, retarget the platform module pin from the PR tip to the merge commit on `main`.

### Changes
- `github.com/moke-game/platform` → `v0.0.0-20260812031638-1fe842e07c0c`
- Refresh `COMPATIBILITY.md`

### Test plan
- [x] `go mod tidy`
- [ ] CI green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-398a3149-3eb1-4944-b716-74b5ecd93293?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-398a3149-3eb1-4944-b716-74b5ecd93293&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

