### PR TITLE
chore: pin platform to #31 merge on main

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -3,8 +3,10 @@
 | Dependency | Version | Notes |
 |------------|---------|-------|
 | moke-kit | `v1.0.5-0.20260812061322-0bee2b36f992` ([#231](https://github.com/GStones/moke-kit/pull/231)) | DocumentBase/NATS tests + create-game smoke/CI |
-| platform | tip `196750cd…` (kit #231 bump) | Depends on [platform kit#231 PR](https://github.com/moke-game/platform/compare/main...cursor/post-merge-kit231-3293); retarget to merge after land |
+| platform | `v0.0.0-20260812062354-338ce51d453a` ([#31](https://github.com/moke-game/platform/pull/31) on `main`) | kit #231 tip bump |
 
 `GrpcModule` / `HttpModule` / `AllModule` do not embed auth — pair `AuthAllModule` (aggregate) or `AuthMiddlewareModule` (thin) in `main`.
+
+Validated by [game#27](https://github.com/moke-game/game/pull/27). This PR retargets the platform pin from the #31 tip to the merge commit on `main`.
 
 Tracking: https://github.com/moke-game/game/issues/18

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0
 	github.com/gstones/moke-kit v1.0.5-0.20260812061322-0bee2b36f992
 	github.com/gstones/zinx v1.2.7-0.20240617071724-88bd884d8d08
-	github.com/moke-game/platform v0.0.0-20260812061609-196750cd2040
+	github.com/moke-game/platform v0.0.0-20260812062353-338ce51d453a
 	github.com/redis/go-redis/v9 v9.7.3
 	github.com/spf13/cobra v1.9.1
 	go.uber.org/fx v1.23.0

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/moke-game/platform v0.0.0-20260812061609-196750cd2040 h1:5XIQcSKiJH+f525AtmGg7xQfr4sTEyI4e/4E7EsiwDU=
-github.com/moke-game/platform v0.0.0-20260812061609-196750cd2040/go.mod h1:qqCg5hcUj3Y1qnVNbf/pLj0UoXE9j44CfwxiBoq9sas=
+github.com/moke-game/platform v0.0.0-20260812062353-338ce51d453a h1:B3+5koJ7zRLaM+fzoEciTR1Mj85Ot8vdG8GDBnuPmSY=
+github.com/moke-game/platform v0.0.0-20260812062353-338ce51d453a/go.mod h1:qqCg5hcUj3Y1qnVNbf/pLj0UoXE9j44CfwxiBoq9sas=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=
 github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
After [#27](https://github.com/moke-game/game/pull/27) / [#31](https://github.com/moke-game/platform/pull/31) merged, retarget the platform module pin from the PR tip to the merge commit on `main`.

### Changes
- `github.com/moke-game/platform` → `v0.0.0-20260812062353-338ce51d453a`
- Refresh `COMPATIBILITY.md`

### Test plan
- [x] `go mod tidy`
- [ ] CI green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-398a3149-3eb1-4944-b716-74b5ecd93293?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-398a3149-3eb1-4944-b716-74b5ecd93293&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

