### PR TITLE
ci: fix buf-push workflow parse error on secrets in if

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -6,6 +6,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -18,8 +20,9 @@ jobs:
           against: "https://github.com/${{ github.repository }}.git#branch=main,ref=HEAD~1"
 
       # Skip when BUF_TOKEN is unset; fail hard when present but invalid.
+      # secrets cannot be used in if:; map the token to env first.
       - name: Push module to BSR
-        if: ${{ secrets.BUF_TOKEN != '' }}
+        if: ${{ env.BUF_TOKEN != '' }}
         uses: bufbuild/buf-push-action@v1
         with:
           buf_token: ${{ secrets.BUF_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Every main-branch run of `.github/workflows/push.yaml` since 2026-08-12 has died in 0 seconds with no jobs. Latest example: [run 31570874357](https://github.com/moke-game/game/actions/runs/31570874357) (merge of PR #28).

PR #24 gated the BSR push with:

```yaml
if: ${{ secrets.BUF_TOKEN != '' }}
```

GitHub Actions does not allow the `secrets` context in `if:` expressions, so the workflow fails at parse time. The sibling repo `moke-game/platform` shows the same annotation: `Unrecognized named-value: 'secrets'`.

## Fix

Map `BUF_TOKEN` to a job-level env var, then gate the step on `env.BUF_TOKEN`:

- Skip the BSR push when the token is unset
- Fail hard when the token is present but invalid

This keeps the intent of the 2026-08-12 change and avoids `continue-on-error: true`, which would hide invalid-token failures.

`actionlint` accepts the updated workflow. Go CI is unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aed26b7a-7a90-41b8-bdc3-66cec3a85d52?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aed26b7a-7a90-41b8-bdc3-66cec3a85d52&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

