### PR TITLE
ci: stop leaking BUF_TOKEN into buf-breaking-action

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -7,7 +7,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
+      # Boolean only — do not set BUF_TOKEN here; buf-breaking-action treats it as a Buf API token.
+      HAS_BUF_TOKEN: ${{ secrets.BUF_TOKEN != '' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -20,9 +21,9 @@ jobs:
           against: "https://github.com/${{ github.repository }}.git#branch=main,ref=HEAD~1"
 
       # Skip when BUF_TOKEN is unset; fail hard when present but invalid.
-      # secrets cannot be used in if:; map the token to env first.
+      # secrets cannot be used in if:; gate on the boolean env instead.
       - name: Push module to BSR
-        if: ${{ env.BUF_TOKEN != '' }}
+        if: ${{ env.HAS_BUF_TOKEN == 'true' }}
         uses: bufbuild/buf-push-action@v1
         with:
           buf_token: ${{ secrets.BUF_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

PR #29 made `.github/workflows/push.yaml` parse, but [run 32225947157](https://github.com/moke-game/game/actions/runs/32225947157) (merge of #29) failed in `bufbuild/buf-breaking-action@v1`:

> Failure: the BUF_TOKEN environment variable is not valid for buf.build. Set BUF_TOKEN to a valid Buf API token, or unset it.

Job-level `env.BUF_TOKEN: ${{ secrets.BUF_TOKEN }}` leaked into every step. The breaking action treats `BUF_TOKEN` as a Buf API token, so an invalid/placeholder secret fails the job before the BSR push step runs (that step was skipped).

## Fix

- Do **not** set `BUF_TOKEN` on the job env.
- Map a boolean `HAS_BUF_TOKEN: ${{ secrets.BUF_TOKEN != '' }}` (allowed in `env:`, not an `if:` secrets check).
- Gate the push step with `if: ${{ env.HAS_BUF_TOKEN == 'true' }}`.
- Pass `buf_token: ${{ secrets.BUF_TOKEN }}` only on the BSR push step.

Unset tokens still skip the push. Present-but-invalid tokens still fail on the push step, not on breaking.

`actionlint` accepts the updated workflow. Go CI is unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aed26b7a-7a90-41b8-bdc3-66cec3a85d52?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aed26b7a-7a90-41b8-bdc3-66cec3a85d52&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

