### PR TITLE
ci: create BSR module on first push (public, match platform)

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -27,3 +27,5 @@ jobs:
         uses: bufbuild/buf-push-action@v1
         with:
           buf_token: ${{ secrets.BUF_TOKEN }}
+          # Match buf.build/moke-game/platform (public). Creates the repo on first push if missing.
+          create_visibility: public


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After PR #30, [run 32227162510](https://github.com/moke-game/game/actions/runs/32227162510) got past buf-breaking, then **Push module to BSR** failed:

> Failure: the server hosted at that remote is unavailable.

The step logged `CREATE_VISIBILITY:` empty. `buf.yaml` names the module `buf.build/moke-game/game`. Draft PR #31 adds `continue-on-error: true`; that is the wrong fix (it hides real push failures).

## Verification

The “repo does not exist” hypothesis is only partly right:

- Unauthenticated BSR API: `buf.build/moke-game/game` **already exists**, created 2024-07-30, last commit 2024-08-30, `VISIBILITY_PUBLIC`.
- Sibling `buf.build/moke-game/platform` is also `VISIBILITY_PUBLIC` and pushed successfully in the same window ([platform run 32227193392](https://github.com/moke-game/platform/actions/runs/32227193392)) without `create_visibility`.
- `create_visibility` is still the right step input: if the module is missing (or this token cannot see it), the first push can create it; if it already exists, the flag is ignored.

## Fix

On the BSR push step only:

```yaml
create_visibility: public
```

Public matches platform (and the existing game BSR repo). The step still fails hard when the token is present but the push fails. No `continue-on-error`. Go CI is unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aed26b7a-7a90-41b8-bdc3-66cec3a85d52?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aed26b7a-7a90-41b8-bdc3-66cec3a85d52&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

